### PR TITLE
Agregar script para simplificar proceso de migración

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "ts-node ./node_modules/typeorm/cli",
-    "migration:run": "npm run typeorm migration:run -- -d ./src/config/connection-source.ts",
+    "migration:run": "ts-node ./src/scripts/migration-run.ts",
     "migration:generate": "ts-node ./src/scripts/generate-migration.ts",
     "migration:create": "ts-node ./src/scripts/create-migration.ts",
     "migration:revert": "npm run typeorm -- -d ./src/config/connection-source.ts migration:revert",

--- a/src/scripts/generate-migration.ts
+++ b/src/scripts/generate-migration.ts
@@ -1,4 +1,4 @@
-import { getArgumentValue, runCommand } from './utils';
+import { MIGRATION_RESOURCE_PATH, getArgumentValue, runCommand } from './utils';
 
 // Obtención de argumentos de la línea de comando (excluyendo los primeros dos).
 const args = process.argv.slice(2);
@@ -7,16 +7,10 @@ const args = process.argv.slice(2);
 const migrationName = getArgumentValue(args, '--name=', 'default_migration_name');
 
 // Proceso de construcción y ejecución de migraciones.
-console.log('Compilando el proyecto...');
+console.log('Compiling project...');
 runCommand('pnpm build');
 
-console.log(`Ejecutando migraciones con nombre: ${migrationName}`);
-// runCommand(`npm run migration:generate --name=${migrationName}`);
-runCommand(
-  `npm run typeorm -- -d ./src/config/connection-source.ts migration:generate ./src/migrations/${migrationName}`,
-);
+console.log(`Generating migrations with name: ${migrationName}`);
+runCommand(`npm run typeorm -- -d ${MIGRATION_RESOURCE_PATH} migration:generate ./src/migrations/${migrationName}`);
 
-console.log('Compilando el proyecto nuevamente...');
-runCommand('pnpm build');
-
-console.log('Proceso completado con éxito.');
+console.log('Process completed successfully.');

--- a/src/scripts/migration-run.ts
+++ b/src/scripts/migration-run.ts
@@ -1,0 +1,9 @@
+import { MIGRATION_RESOURCE_PATH, runCommand } from './utils';
+
+console.log('Compiling project...');
+runCommand('pnpm build');
+
+console.log('Running migrations...');
+runCommand(`npm run typeorm migration:run -- -d ${MIGRATION_RESOURCE_PATH}`);
+
+console.log('Project compiled and migrations run successfully.');

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'child_process';
 
+export const MIGRATION_RESOURCE_PATH = './src/config/connection-source.ts';
+
 // Función para extraer el valor de un argumento con un prefijo dado, con un valor por defecto.
 export function getArgumentValue(args, prefix, defaultValue) {
   for (const arg of args) {


### PR DESCRIPTION
Este PR agrega un nuevo script para facilitar el proceso de migración de la aplicación. Con este cambio, ya no es necesario ejecutar manualmente `pnpm run build` antes de `migration:run`, ya que el script se encarga de realizar este paso previo automáticamente.